### PR TITLE
Fix FAB states on detail view

### DIFF
--- a/app/src/main/java/com/example/peterchu/watplanner/coursedetail/CourseDetailFragment.java
+++ b/app/src/main/java/com/example/peterchu/watplanner/coursedetail/CourseDetailFragment.java
@@ -6,6 +6,7 @@ import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.view.ViewCompat;
+import android.support.v4.view.ViewPropertyAnimatorCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
@@ -32,6 +33,8 @@ public class CourseDetailFragment extends Fragment implements BaseView<CourseDet
 
     private View rootView;
     private FloatingActionButton fab;
+
+    private boolean isFabRotated = false;
 
     @Override
     public void setPresenter(CourseDetailPresenter presenter) {
@@ -103,19 +106,16 @@ public class CourseDetailFragment extends Fragment implements BaseView<CourseDet
         fab.setImageResource(R.drawable.ic_clear_white_24px);
     }
 
-    public void rotateFabForward() {
-        ViewCompat.animate(fab)
-                .rotation(45.0F)
-                .withLayer()
-                .setDuration(300L)
-                .setInterpolator(new DecelerateInterpolator())
-                .start();
-    }
-
-    public void rotateFabBackward() {
-        ViewCompat.animate(fab)
-                .rotation(0.0F)
-                .withLayer()
+    public void toggleFabRotation() {
+        ViewPropertyAnimatorCompat animator = ViewCompat.animate(fab);
+        if (isFabRotated) {
+            animator = animator.rotation(0.0F);
+            isFabRotated = false;
+        } else {
+            animator = animator.rotation(45.0F);
+            isFabRotated = true;
+        }
+        animator.withLayer()
                 .setDuration(300L)
                 .setInterpolator(new DecelerateInterpolator())
                 .start();

--- a/app/src/main/java/com/example/peterchu/watplanner/coursedetail/CourseDetailPresenter.java
+++ b/app/src/main/java/com/example/peterchu/watplanner/coursedetail/CourseDetailPresenter.java
@@ -95,14 +95,13 @@ class CourseDetailPresenter implements BasePresenter {
         if (isAddedCourse) {
             isAddedCourse = false;
             courseDetailFragment.showRemovedMessage();
-            courseDetailFragment.rotateFabForward();
             addedCourses.remove(String.valueOf(courseId));
         } else {
             isAddedCourse = true;
             courseDetailFragment.showAddedMessage();
-            courseDetailFragment.rotateFabBackward();
             addedCourses.add(String.valueOf(courseId));
         }
+        courseDetailFragment.toggleFabRotation();
 
         sharedPreferences.edit()
                 .remove(Constants.SHARED_PREFS_ADDED_COURSES)


### PR DESCRIPTION
Issue was rotation goes to 45 degrees when course is added and 0 degrees when course is removed. If you enter the detail view on a course you haven't added and tap the FAB, it animated to 0 degrees which wouldn't do anything.

Fix: Have the view just toggle between the two rotation degrees regardless of added/removed state.

This approach has less repeated code too lol.