### PR TITLE
fix week view

### DIFF
--- a/app/src/main/java/com/example/peterchu/watplanner/Models/Schedule/CourseComponent.java
+++ b/app/src/main/java/com/example/peterchu/watplanner/Models/Schedule/CourseComponent.java
@@ -254,8 +254,6 @@ public class CourseComponent {
     public List<WeekViewEvent> toWeekViewEvents(int month) {
         List<WeekViewEvent> weekViewEvents = new ArrayList<WeekViewEvent>();
         try {
-            Calendar eventStartDate = this.getCalendarStartTime();
-            Calendar eventEndDate = this.getCalendarEndTime();
             String eventName = String.format("%s %s %s", subject, catalogNumber, type);
 
             Calendar date = Calendar.getInstance();
@@ -269,6 +267,8 @@ public class CourseComponent {
                 return new ArrayList<WeekViewEvent>();
             }
             while (date.get(Calendar.MONTH) == month) {
+                Calendar eventStartDate = this.getCalendarStartTime();
+                Calendar eventEndDate = this.getCalendarEndTime();
                 if (Integer.valueOf(date.get(Calendar.DAY_OF_WEEK)) == this.getDayOfWeek()) {
                     WeekViewCourseEvent event = new WeekViewCourseEvent(this);
 


### PR DESCRIPTION
basically, since WeekViewEvent just keeps a reference to the calendar object passed in (and doesn't make a copy of it), we have to create a new calendar instance every time in the loop. Components will now show properly again in the view.