### PR TITLE
Remove duplicates from scheduler alternative generation

### DIFF
--- a/app/src/main/java/com/example/peterchu/watplanner/home/HomeFragment.java
+++ b/app/src/main/java/com/example/peterchu/watplanner/home/HomeFragment.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -237,7 +238,7 @@ public class HomeFragment extends Fragment implements BaseView<HomePresenter> {
 
     public void showConflictFreeAlternativesDialog(
             CourseComponent course,
-            List<List<CourseComponent>> alternatives) {
+            Set<List<CourseComponent>> alternatives) {
         ConflictResolveItemView alternateSlotView = new ConflictResolveItemView(
                 HomeFragment.this.getContext(),
                 course);

--- a/app/src/main/java/com/example/peterchu/watplanner/home/HomeFragment.java
+++ b/app/src/main/java/com/example/peterchu/watplanner/home/HomeFragment.java
@@ -4,7 +4,6 @@ import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.graphics.Color;
 import android.graphics.RectF;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -37,8 +36,6 @@ import com.miguelcatalan.materialsearchview.MaterialSearchView;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
-import java.util.Random;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/app/src/main/java/com/example/peterchu/watplanner/home/HomeFragment.java
+++ b/app/src/main/java/com/example/peterchu/watplanner/home/HomeFragment.java
@@ -238,7 +238,7 @@ public class HomeFragment extends Fragment implements BaseView<HomePresenter> {
 
     public void showConflictFreeAlternativesDialog(
             CourseComponent course,
-            Set<List<CourseComponent>> alternatives) {
+            List<List<CourseComponent>> alternatives) {
         ConflictResolveItemView alternateSlotView = new ConflictResolveItemView(
                 HomeFragment.this.getContext(),
                 course);

--- a/app/src/main/java/com/example/peterchu/watplanner/home/HomePresenter.java
+++ b/app/src/main/java/com/example/peterchu/watplanner/home/HomePresenter.java
@@ -171,7 +171,7 @@ class HomePresenter implements BasePresenter {
     }
 
     public void onCalendarEventClicked(CourseComponent courseComponent) {
-        Set<List<CourseComponent>> alternatives;
+        List<List<CourseComponent>> alternatives;
         try {
             alternatives = scheduler.getAlternateSections(courseComponent);
         } catch (ContradictionException e) {

--- a/app/src/main/java/com/example/peterchu/watplanner/home/HomePresenter.java
+++ b/app/src/main/java/com/example/peterchu/watplanner/home/HomePresenter.java
@@ -171,7 +171,7 @@ class HomePresenter implements BasePresenter {
     }
 
     public void onCalendarEventClicked(CourseComponent courseComponent) {
-        List<List<CourseComponent>> alternatives;
+        Set<List<CourseComponent>> alternatives;
         try {
             alternatives = scheduler.getAlternateSections(courseComponent);
         } catch (ContradictionException e) {

--- a/app/src/main/java/com/example/peterchu/watplanner/scheduler/CourseScheduler.java
+++ b/app/src/main/java/com/example/peterchu/watplanner/scheduler/CourseScheduler.java
@@ -138,9 +138,9 @@ public class CourseScheduler {
      * Given a course component, this will determine what other section that the component can
      * switch into and still maintain a conflict-free schedule.
      */
-    public List<List<CourseComponent>> getAlternateSections(CourseComponent component)
+    public Set<List<CourseComponent>> getAlternateSections(CourseComponent component)
             throws ContradictionException {
-        List<List<CourseComponent>> ret = new ArrayList<>();
+        Set<List<CourseComponent>> ret = new HashSet<>();
         for (Solution solution : solver.getSolutionRecorder().getSolutions()) {
             solver.getSearchLoop().restoreRootNode();
             solver.getEnvironment().worldPush();

--- a/app/src/main/java/com/example/peterchu/watplanner/scheduler/CourseScheduler.java
+++ b/app/src/main/java/com/example/peterchu/watplanner/scheduler/CourseScheduler.java
@@ -138,9 +138,9 @@ public class CourseScheduler {
      * Given a course component, this will determine what other section that the component can
      * switch into and still maintain a conflict-free schedule.
      */
-    public Set<List<CourseComponent>> getAlternateSections(CourseComponent component)
+    public List<List<CourseComponent>> getAlternateSections(CourseComponent component)
             throws ContradictionException {
-        Set<List<CourseComponent>> ret = new HashSet<>();
+        List<List<CourseComponent>> ret = new ArrayList<>();
         for (Solution solution : solver.getSolutionRecorder().getSolutions()) {
             solver.getSearchLoop().restoreRootNode();
             solver.getEnvironment().worldPush();
@@ -149,7 +149,8 @@ public class CourseScheduler {
                 List<CourseComponent> c = entry.getValue();
                 if (entry.getKey().getValue() == 1
                         && isSameCourse(component, c.get(0))
-                        && !component.getSection().equals(c.get(0).getSection())) {
+                        && !component.getSection().equals(c.get(0).getSection())
+                        && !ret.contains(c)) {
                     ret.add(c);
                 }
             }


### PR DESCRIPTION
Issue was that each solution of the SAT solver can have the same section for certain class type (LEC, TUT, etc.).

We use a Set to ensure duplicates aren't returned.