### PR TITLE
Pc/export course schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# WATPlanner
+

--- a/app/src/main/java/com/example/peterchu/watplanner/Models/Schedule/CourseComponent.java
+++ b/app/src/main/java/com/example/peterchu/watplanner/Models/Schedule/CourseComponent.java
@@ -59,6 +59,18 @@ public class CourseComponent {
 
     private String term;
 
+    private int id;
+
+    private Integer calendarId;
+
+    private Integer eventId;
+
+    private String courseId;
+
+    public int getId() { return id; }
+
+    public void setId(int id) { this.id = id; }
+
     public String getType() {
         return type;
     }
@@ -175,7 +187,7 @@ public class CourseComponent {
         this.day = day;
     }
 
-    public void setTerm(String day) {
+    public void setTerm(String term) {
         this.term = term;
     }
 
@@ -240,22 +252,40 @@ public class CourseComponent {
         return cal;
     }
 
-    public Calendar getCalendarStartTime() {
+    /**
+     * Gets the first calendar event start time of recurring course component event
+     * Goes to the first day of the week that the course component is on after the term start date
+     * @return the first calendar event start time
+     */
+    public Calendar getFirstCalendarStartTime() {
         try {
             Calendar cal = this.getTermStartDate();
+            while (cal.get(Calendar.DAY_OF_WEEK) != this.getDayOfWeek()) {
+                cal.add(Calendar.DATE, 1);
+            }
             Date date = componentDateFormat.parse(this.startTime);
-            cal.setTime(date);
+            cal.set(Calendar.HOUR, date.getHours());
+            cal.set(Calendar.MINUTE, date.getMinutes());
             return cal;
         } catch (ParseException e) {
             return null;
         }
     }
 
-    public Calendar getCalendarEndTime() {
+    /**
+     * Gets the first calendar event end time of recurring course component event
+     * Goes to the first day of the week that the course component is on after the term start date
+     * @return the first calendar event end time
+     */
+    public Calendar getFirstCalendarEndTime() {
         try {
             Calendar cal = this.getTermStartDate();
+            while (cal.get(Calendar.DAY_OF_WEEK) != this.getDayOfWeek()) {
+                cal.add(Calendar.DATE, 1);
+            }
             Date date = componentDateFormat.parse(this.endTime);
-            cal.setTime(date);
+            cal.set(Calendar.HOUR, date.getHours());
+            cal.set(Calendar.MINUTE, date.getMinutes());
             return cal;
         } catch (ParseException e) {
             return null;
@@ -276,8 +306,8 @@ public class CourseComponent {
                 return new ArrayList<>();
             }
             while (date.get(Calendar.MONTH) == month) {
-                Calendar eventStartDate = this.getCalendarStartTime();
-                Calendar eventEndDate = this.getCalendarEndTime();
+                Calendar eventStartDate = this.getFirstCalendarStartTime();
+                Calendar eventEndDate = this.getFirstCalendarEndTime();
                 if (Integer.valueOf(date.get(Calendar.DAY_OF_WEEK)) == this.getDayOfWeek()) {
                     WeekViewCourseEvent event = new WeekViewCourseEvent(this);
 
@@ -328,5 +358,25 @@ public class CourseComponent {
     public String getTermEndDate() {
         // TODO: need to actually fetch term info later
         return "20170725";
+    }
+
+    public Integer getCalendarId() {
+        return calendarId;
+    }
+
+    public void setCalendarId(Integer calendarId) {
+        this.calendarId = calendarId;
+    }
+
+    public Integer getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(Integer eventId) {
+        this.eventId = eventId;
+    }
+
+    public void setCourseId(String courseId) {
+        this.courseId = courseId;
     }
 }

--- a/app/src/main/java/com/example/peterchu/watplanner/data/DataRepository.java
+++ b/app/src/main/java/com/example/peterchu/watplanner/data/DataRepository.java
@@ -241,6 +241,11 @@ public class DataRepository implements IDataRepository {
                 Constants.SHARED_PREFS_ADDED_COURSES, new HashSet<String>());
     }
 
+    @Override
+    public void associateCourseComponentEvent(int id, long calId, long eventId) {
+        databaseHandler.associateCourseComponentEvent(id, calId, eventId);
+    }
+
     public interface SyncDataCallback {
         void onDataSynced();
 

--- a/app/src/main/java/com/example/peterchu/watplanner/data/IDataRepository.java
+++ b/app/src/main/java/com/example/peterchu/watplanner/data/IDataRepository.java
@@ -71,4 +71,12 @@ public interface IDataRepository {
     Course getCourse(int courseId);
 
     Set<String> getUserCourses();
+
+    /**
+     * Associates a course component with a calender ID and an event ID in the Android calendar
+     * @param id the course component ID
+     * @param calID the Android calendar ID
+     * @param eventID the Android event ID
+     */
+    void associateCourseComponentEvent(int id, long calID, long eventID);
 }

--- a/app/src/main/java/com/example/peterchu/watplanner/home/HomeFragment.java
+++ b/app/src/main/java/com/example/peterchu/watplanner/home/HomeFragment.java
@@ -176,7 +176,7 @@ public class HomeFragment extends Fragment implements BaseView<HomePresenter> {
             public void onClick(DialogInterface dialog, int which) {
                 // TODO: Replace empty list with the configuration of course components for courses
                 // that the user selected/SAT solver came up with
-                homePresenter.onExportCoursesToCalendar(new ArrayList<CourseComponent>());
+                homePresenter.onExportCoursesToCalendar(mCourseSchedule);
             }
         });
 


### PR DESCRIPTION
1) add fields for calendar ID and event ID in the course schedule table to associate with user's exported calendar schedule (this is so we don't export the same course component more than once)
also with the event ID, we can:
-delete the event on removing the course component from schedule if we want to
-update these course components if we want with reminders later

2) export the schedule on the home page to the user's default calendar

3) add course ID to CourseComponent (for @Mrez95)

3) add term to CourseComponent (for future maintainability for different terms)

Breaking change - this will require a reinstall and install (maybe also dbHandler.destroyAndRecreateDb()) :)