### PR TITLE
make most of calendar day visible

### DIFF
--- a/app/src/main/res/layout/home_fragment.xml
+++ b/app/src/main/res/layout/home_fragment.xml
@@ -53,7 +53,7 @@
                         <com.alamkanak.weekview.WeekView
                             android:id="@+id/weekViewHome"
                             android:layout_width="match_parent"
-                            android:layout_height="300dp"
+                            android:layout_height="500dp"
                             app:columnGap="8dp"
                             app:dayBackgroundColor="#05000000"
                             app:eventTextColor="@android:color/white"


### PR DESCRIPTION
it's hard/impossible to vertically scroll for some reason when there are courses in the calendar. This height change makes 8am-7pm visible on my phone. Let's do this until we figure out why vertical scroll is broken